### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Shiny App for Analysing Boreal Caribou Surival, Recruitment and
     Lambda
 Version: 0.3.1
 Authors@R: c(
-    person("Pearson", "Ayla", , "ayla@poissonconsulting.ca", role = c("aut", "cre"),
+    person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7388-1222")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0002-7683-4592")),


### PR DESCRIPTION
Fix swapped given/family name for Ayla Pearson (was "Pearson Ayla").

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)