### PR TITLE
Standardize CI (tier: important)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 permissions:
   contents: read
 jobs:
@@ -12,6 +12,7 @@ jobs:
     with:
       tier: important
       jags: false
+      cmdstan: false
       tex: false
       private: false
     secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
   release:
     types: [published]
   workflow_dispatch:
@@ -13,5 +13,6 @@ jobs:
   pkgdown:
     uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
     with:
+      cmdstan: false
       private: false
     secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,13 +3,14 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 permissions:
   contents: read
 jobs:
   test-coverage:
     uses: poissonconsulting/.github/.github/workflows/test-coverage.yaml@v1
     with:
+      cmdstan: false
       tex: false
       private: false
     secrets: inherit


### PR DESCRIPTION
Closes #34.

Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **important**, private=false, jags=false, cmdstan=false, tex=false). Callers: R-CMD-check, test-coverage, pkgdown; fledge callers migrated to the .yaml templates where present.